### PR TITLE
fix wrong help category

### DIFF
--- a/cogs/tools/help.py
+++ b/cogs/tools/help.py
@@ -62,12 +62,12 @@ class HelpCommand(commands.Cog):
             color=discord.Color.orange(),
             description=react_commands
         )
-        stats = discord.Embed(
+        marry = discord.Embed(
             title=f"{self.bot.user.name} - Свадьбы",
             color=discord.Color.orange(),
             description=stats_commands
         )
-        marry = discord.Embed(
+        stats = discord.Embed(
             title=f"{self.bot.user.name} - Статистика",
             color=discord.Color.orange(),
             description=marry_commands


### PR DESCRIPTION
*Жду пиздюлей за говнокод*

## Подробные изменения

- При использованим команды `/help` и выборе категории команд "статистика" в эмбеде написано что это свадьбы, а при выборе категории "свадьбы" соответственно наоборот пишет что это статистика. **Исправлено**

## Чеклист 
Поставьте `x` в квадратных скобках, чтобы поставить галочку.

- [x] Изменённый код должен быть протестирован.
    - [ ] Я также обновил changelog.md для показа изменений.
- [ ] Поправка исправляет запрос.
- [ ] Поправка добавляет что-то новое.
- [x] Поправка исправляет баг.
- [ ] Поправка **не изменяет код** (редактирование `README`, орфографические исправления, т.д.).
